### PR TITLE
Add nerfstudio loader test and translation init

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ TLDR: models can be trained with:
 
 `python3 train.py --data_path {path_to_data} --name {checkpoint_name}`
 
+The `{path_to_data}` argument may point to either a `frame_bundle.npz` file or
+a directory containing a `transforms.json` file in the Nerfstudio dataset
+format.
+
 For a full list of training arguments, we recommend looking through the argument parser section at the bottom of `\train.py`.
 
 The final model checkpoint will be saved to `checkpoints/{checkpoint_name}/last.ckpt`

--- a/tests/test_nerfstudio_loader.py
+++ b/tests/test_nerfstudio_loader.py
@@ -1,0 +1,58 @@
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from train import BundleDataset
+
+
+def create_dummy_dataset(tmp_path: Path):
+    dataset_dir = tmp_path / "ds"
+    dataset_dir.mkdir()
+
+    frames = []
+    for i in range(2):
+        img = Image.new("RGB", (4, 4), color=(i * 40, 0, 255 - i * 40))
+        img_path = dataset_dir / f"{i:03d}.png"
+        img.save(img_path)
+        frames.append({
+            "file_path": f"./{i:03d}.png",
+            "fl_x": 2.0,
+            "fl_y": 2.0,
+            "cx": 2.0,
+            "cy": 2.0,
+            "w": 4,
+            "h": 4,
+            "transform_matrix": [
+                [1, 0, 0, i * 0.1],
+                [0, 1, 0, 0],
+                [0, 0, 1, 0],
+                [0, 0, 0, 1],
+            ],
+        })
+    with open(dataset_dir / "transforms.json", "w") as f:
+        json.dump({"frames": frames}, f)
+    return dataset_dir
+
+
+def test_nerfstudio_loader(tmp_path):
+    ds_dir = create_dummy_dataset(tmp_path)
+    args = Namespace(
+        data_path=str(ds_dir),
+        frames=None,
+        point_batch_size=8,
+        num_batches=1,
+        rolling_shutter=False,
+        cache=False,
+        max_percentile=100,
+    )
+
+    dataset = BundleDataset(args)
+    dataset.load_volume()
+
+    assert dataset.num_frames == 2
+    assert dataset.rgb_volume.shape == (2, 3, 4, 4)
+    sample = dataset[0]
+    assert len(sample) == 6


### PR DESCRIPTION
## Summary
- use camera translations from nerfstudio transforms.json
- initialise `TranslationModel` center from dataset when available
- add dedicated test for loading nerfstudio style datasets

## Testing
- `python -m py_compile train.py utils/utils.py tests/test_nerfstudio_loader.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685ea4bd1d28832daf5d981c199789e7